### PR TITLE
Tweaks to repository methods such that consumers don't need to interact with mappers

### DIFF
--- a/GRADSAPI.md
+++ b/GRADSAPI.md
@@ -174,14 +174,29 @@
 * @return void
 * @throws Error
 
-#### fetchCustomers()
+#### getAll()
 
 * @return Array[CustomerDataModel]
 * @throws Error
 
-#### fetchCustomer(ID)
+#### findById(ID)
 
 * @params
     * ID - Integer - The ID of the customer to fetch
 * @return CustomerDataModel
+* @throws Error
+
+#### save(CustomerDataModel)
+
+* @params
+    * CustomerDataModel - The representation of the customer to save to the store
+* @return CustomerDataModel
+* @throws Error
+
+
+#### delete(CustomerDataModel)
+
+* @params
+    * CustomerDataModel - The representation of the Customer that we should delete
+* @return void
 * @throws Error


### PR DESCRIPTION
Extending repository interface slightly means that the mappers can be purely internal concerns, and consumers (ie. domain services) only have to interact with the CustomerRepository.